### PR TITLE
Fix issue Music auto-plays when receiving call #40

### DIFF
--- a/YT Music/Controllers/ViewController + MediaKeys.swift
+++ b/YT Music/Controllers/ViewController + MediaKeys.swift
@@ -18,8 +18,8 @@ extension ViewController: MediaKeyTapDelegate {
     func registerRemoteCommands() {
         if #available(OSX 10.12.2, *) {
             let commandCenter = MPRemoteCommandCenter.shared()
-            commandCenter.playCommand.addTarget(self, action: #selector(playPause))
-            commandCenter.pauseCommand.addTarget(self, action: #selector(playPause))
+            commandCenter.playCommand.addTarget(self, action: #selector(play))
+            commandCenter.pauseCommand.addTarget(self, action: #selector(pause))
             commandCenter.togglePlayPauseCommand.addTarget(self, action: #selector(playPause))
             commandCenter.nextTrackCommand.addTarget(self, action: #selector(nextTrack))
             commandCenter.previousTrackCommand.addTarget(self, action: #selector(previousTrack))
@@ -50,6 +50,18 @@ extension ViewController: MediaKeyTapDelegate {
     
     @objc func playPause() {
         clickElement(selector: ".play-pause-button")
+    }
+    
+    @objc func pause() {
+        if (MediaCenter.default.isPlaying) {
+            clickElement(selector: ".play-pause-button")
+        }
+    }
+    
+    @objc func play() {
+        if (!MediaCenter.default.isPlaying) {
+            clickElement(selector: ".play-pause-button")
+        }
     }
     
     @objc func nextTrack() {


### PR DESCRIPTION
This pull request fixes issue #40 
MPRemoteCommandCenter calls the method "pauseCommand" when macOS receives a FaceTime Call and calls the method "playCommand" when FaceTime Call ends.

To fix this issue, I've created a method "pause" that will click at ".play-pause-button" if music is playing and also a method "play" that will click at ".play-pause-button" if music isn't playing.

I hope this piece of code helps you!