### PR TITLE
Set NSRequiresAquaSystemAppearance to false

### DIFF
--- a/YT Music/Info.plist
+++ b/YT Music/Info.plist
@@ -37,5 +37,7 @@
 	<string>NSApplication</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<string>False</string>
 </dict>
 </plist>


### PR DESCRIPTION
This ensures that the app can be a "proper" dark mode to macOS, eliminating the white line at the top and making native context menus dark in dark mode.