### PR TITLE
Remove non-functional native macOS media controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+* Media control keys not responding on newer versions of macOS. [#57](https://github.com/steve228uk/YouTube-Music/pull/57)
+* Content not appearing in macOS Big Sur. [#130](https://github.com/steve228uk/YouTube-Music/pull/130)
+
 ## [1.1.0] - 2021-04-24
 
 G'day everyone! Tim here! It took a fair few weeks of R&D (including [a PR to fastlane](https://github.com/fastlane/fastlane/pull/18496) itself!), but with Steve's blessing, I've finally managed to remove DevMateKit and replace it with an automated build system around GitHub Actions that will enable creating release updates of YT Music *far* more frequently than before.

--- a/YT Music/Controllers/ViewController + MediaKeys.swift
+++ b/YT Music/Controllers/ViewController + MediaKeys.swift
@@ -14,7 +14,6 @@ import MediaPlayer
 #endif
 
 extension ViewController: MediaKeyTapDelegate {
-    
     func registerRemoteCommands() {
         if #available(OSX 10.12.2, *) {
             let commandCenter = MPRemoteCommandCenter.shared()
@@ -26,10 +25,9 @@ extension ViewController: MediaKeyTapDelegate {
             commandCenter.previousTrackCommand.addTarget(self, action: #selector(previousTrack))
             commandCenter.previousTrackCommand.isEnabled = true
             commandCenter.changePlaybackPositionCommand.addTarget(self, action: #selector(seek(_:)))
-        } else {
-            mediaKeyTap = MediaKeyTap(delegate: self)
-            mediaKeyTap?.start()
         }
+        mediaKeyTap = MediaKeyTap(delegate: self)
+        mediaKeyTap?.start()
     }
     
     func handle(mediaKey: MediaKey, event: KeyEvent) {
@@ -44,7 +42,7 @@ extension ViewController: MediaKeyTapDelegate {
         case .next, .fastForward:
             nextTrack()
             break
-        case.previous, .rewind:
+        case .previous, .rewind:
             previousTrack()
             break
         }

--- a/YT Music/Controllers/ViewController + MediaKeys.swift
+++ b/YT Music/Controllers/ViewController + MediaKeys.swift
@@ -15,17 +15,6 @@ import MediaPlayer
 
 extension ViewController: MediaKeyTapDelegate {
     func registerRemoteCommands() {
-        if #available(OSX 10.12.2, *) {
-            let commandCenter = MPRemoteCommandCenter.shared()
-            commandCenter.playCommand.addTarget(self, action: #selector(play))
-            commandCenter.pauseCommand.addTarget(self, action: #selector(pause))
-            commandCenter.togglePlayPauseCommand.addTarget(self, action: #selector(playPause))
-            commandCenter.nextTrackCommand.addTarget(self, action: #selector(nextTrack))
-            commandCenter.nextTrackCommand.isEnabled = true
-            commandCenter.previousTrackCommand.addTarget(self, action: #selector(previousTrack))
-            commandCenter.previousTrackCommand.isEnabled = true
-            commandCenter.changePlaybackPositionCommand.addTarget(self, action: #selector(seek(_:)))
-        }
         mediaKeyTap = MediaKeyTap(delegate: self)
         mediaKeyTap?.start()
     }


### PR DESCRIPTION
This is a cleaned up version of #57 that also fixes the app not working properly in Big Sur.

For the life of me, I couldn't get the native `MPRemoteCommandCenter` API to work. Pressing the media keys on my keyboard wouldn't do anything. I think this is because the `WKWebView` itself is hijacking media control.

This was already solved in #57 where it simply removes using the system, and directly binds the media keys to this app. It's not an amazing solution (Since it does require asking for Accessibility permission), but it works, and hopefully we can refine from here.