### PR TITLE
Update CI to use macOS 11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     name: 'Run Unit Tests'
 
     # Run on latest supported macOS version
-    runs-on: macOS-latest
+    runs-on: macOS-11
 
     steps:
 


### PR DESCRIPTION
GitHub just confirmed with me that they've enabled Big Sur support for this repo. Yay!

This PR updates the CI workflow script in order to try this out.