### PR TITLE
fix search enter, create a shortcut for search

### DIFF
--- a/YT Music/AppDelegate.swift
+++ b/YT Music/AppDelegate.swift
@@ -90,5 +90,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .performSelector(onMainThread: #selector(ViewController.shuffleTracks), with: nil, waitUntilDone: true)
     }
     
+    @IBAction func startSearch(_ sender: Any) {
+        mainWindowController?.window?.contentViewController?
+            .performSelector(onMainThread: #selector(ViewController.startSearch), with: nil, waitUntilDone: true)
+    }
 }
 

--- a/YT Music/Base.lproj/Main.storyboard
+++ b/YT Music/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -144,6 +144,11 @@
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                             <connections>
                                                 <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show Search" keyEquivalent="f" id="rQS-29-aIX">
+                                            <connections>
+                                                <action selector="startSearch:" target="Voe-Tx-rLC" id="jws-8k-5oc"/>
                                             </connections>
                                         </menuItem>
                                     </items>

--- a/YT Music/Controllers/ViewController + MediaKeys.swift
+++ b/YT Music/Controllers/ViewController + MediaKeys.swift
@@ -39,6 +39,13 @@ extension ViewController: MediaKeyTapDelegate {
             }
             hotKey.register()
         }
+        
+        if let keyCombo = KeyCombo(key: .f, cocoaModifiers: [.command]) {
+            let hotKey = HotKey(identifier: "CommandF", keyCombo: keyCombo) { hotKey in
+                self.startSearch();
+            }
+            hotKey.register()
+        }
     }
     
     func handle(mediaKey: MediaKey, event: KeyEvent) {
@@ -97,6 +104,15 @@ extension ViewController: MediaKeyTapDelegate {
     
     @objc func repeatTracks() {
         clickElement(selector: ".repeat")
+    }
+    
+    @objc func startSearch() {
+        let js = "var elem = document.getElementsByTagName('ytmusic-search-box')[0]; elem.setAttribute('opened', '');"
+        webView.evaluateJavaScript(js) { (_, error) in
+            if let error = error {
+                print(error)
+            }
+        }
     }
     
     func clickElement(selector: String) {

--- a/YT Music/Controllers/ViewController + MediaKeys.swift
+++ b/YT Music/Controllers/ViewController + MediaKeys.swift
@@ -40,8 +40,8 @@ extension ViewController: MediaKeyTapDelegate {
             hotKey.register()
         }
         
-        if let keyCombo = KeyCombo(key: .f, cocoaModifiers: [.command]) {
-            let hotKey = HotKey(identifier: "CommandF", keyCombo: keyCombo) { hotKey in
+        if let keyCombo = KeyCombo(key: .f, cocoaModifiers: [.command, .shift]) {
+            let hotKey = HotKey(identifier: "CommandShiftF", keyCombo: keyCombo) { hotKey in
                 self.startSearch();
             }
             hotKey.register()

--- a/YT Music/Controllers/ViewController + MediaKeys.swift
+++ b/YT Music/Controllers/ViewController + MediaKeys.swift
@@ -39,13 +39,6 @@ extension ViewController: MediaKeyTapDelegate {
             }
             hotKey.register()
         }
-        
-        if let keyCombo = KeyCombo(key: .f, cocoaModifiers: [.command, .shift]) {
-            let hotKey = HotKey(identifier: "CommandShiftF", keyCombo: keyCombo) { hotKey in
-                self.startSearch();
-            }
-            hotKey.register()
-        }
     }
     
     func handle(mediaKey: MediaKey, event: KeyEvent) {

--- a/YT Music/Controllers/ViewController.swift
+++ b/YT Music/Controllers/ViewController.swift
@@ -78,7 +78,7 @@ class ViewController: NSViewController {
             standardButtonsView.addSubview(btn)
         }
         
-        movableView.frame = CGRect(x: 0, y: webView.isFlipped ? 0 : webView.frame.height - 20, width: webView.frame.width, height: 20)
+        movableView.frame = CGRect(x: 0, y: webView.isFlipped ? 0 : webView.frame.height - 20, width: webView.frame.width, height: 64)
         
         let y = webView.isFlipped ? 14 : webView.frame.height - 46
         
@@ -150,7 +150,8 @@ class ViewController: NSViewController {
     
     func addMovableView() {
         movableView = WindowMovableView(frame: .zero)
-        movableView.frame = CGRect(x: 0, y: 0, width: webView.frame.width, height: 20)
+        movableView.parent = webView
+        movableView.frame = CGRect(x: 0, y: 0, width: webView.frame.width, height: 64)
         webView.addSubview(movableView)
     }
     

--- a/YT Music/Views/CustomWebView.swift
+++ b/YT Music/Views/CustomWebView.swift
@@ -14,27 +14,4 @@ class CustomWebView: WKWebView {
     override var isOpaque: Bool {
         return true
     }
-    
-    override func keyDown(with event: NSEvent) {
-        
-        // Check if the enter key is being pressed else let the super handle the event.
-        guard let value = event.charactersIgnoringModifiers, value == "\r" else {
-            super.keyDown(with: event)
-            return
-        }
-        
-        // If enter is being pressed then we manually handle it in JS.
-        // There's a condition in here to select the .selected-suggestion if there is one else we dispatch the event on activeElement.
-        
-        let js = "var elem = document.querySelector('.selected-suggestion'); if(!elem) { elem = document.activeElement; } elem.dispatchEvent(new KeyboardEvent('keydown', { view: window, keyCode: 13, bubbles: true, cancelable: true }));"
-        
-        evaluateJavaScript(js) { (_, error) in
-            if let error = error {
-                print(error)
-            }
-        }
-        
-        
-    }
-    
 }

--- a/YT Music/Views/WindowMovableView.swift
+++ b/YT Music/Views/WindowMovableView.swift
@@ -10,6 +10,8 @@ import Cocoa
 
 class WindowMovableView: NSView {
     
+    weak var parent: NSView?
+    
     override var mouseDownCanMoveWindow: Bool {
         return true
     }
@@ -27,8 +29,19 @@ class WindowMovableView: NSView {
     }
     
     override func mouseUp(with event: NSEvent) {
-        guard event.clickCount == 2, let window = window else { return }
-        window.setIsZoomed(!window.isZoomed)
+        
+        guard let window = window else {
+            return
+        }
+        
+        switch event.clickCount {
+        case 1:
+            parent?.mouseUp(with: event)
+        case 2:
+            window.setIsZoomed(!window.isZoomed)
+        default:
+            break
+        }
     }
     
 }


### PR DESCRIPTION
- remove `keyDown` override, so that when search press enter will go super keyDown directly, #148 
- add shortcut `Command  + F` for quick callout search window, #123
- make nav bar height into 64 px, handle single click event pass through to webview