### PR TITLE
revert draggable area back to 20px height

### DIFF
--- a/YT Music/Controllers/ViewController.swift
+++ b/YT Music/Controllers/ViewController.swift
@@ -78,7 +78,7 @@ class ViewController: NSViewController {
             standardButtonsView.addSubview(btn)
         }
         
-        movableView.frame = CGRect(x: 0, y: webView.isFlipped ? 0 : webView.frame.height - 20, width: webView.frame.width, height: 64)
+        movableView.frame = CGRect(x: 0, y: webView.isFlipped ? 0 : webView.frame.height - 20, width: webView.frame.width, height: 20)
         
         let y = webView.isFlipped ? 14 : webView.frame.height - 46
         
@@ -151,7 +151,7 @@ class ViewController: NSViewController {
     func addMovableView() {
         movableView = WindowMovableView(frame: .zero)
         movableView.parent = webView
-        movableView.frame = CGRect(x: 0, y: 0, width: webView.frame.width, height: 64)
+        movableView.frame = CGRect(x: 0, y: 0, width: webView.frame.width, height: 20)
         webView.addSubview(movableView)
     }
     


### PR DESCRIPTION
 #161 

@jscheel @TimOliver 

before found any solution for the hittest priority in-between WKWebview & NSView, temporary revert the code.
the window draggable area will reduce to 20px from top (red area) rather than 64px (amber red area)

<img width="1581" alt="Screenshot 2022-04-23 at 1 57 56 AM" src="https://user-images.githubusercontent.com/5100535/164769912-f17fbad5-72d1-4456-af06-7479176b69c5.png">
 