### PR TITLE
Block service worker from loading, (see #163)

### DIFF
--- a/YT Music.xcodeproj/project.pbxproj
+++ b/YT Music.xcodeproj/project.pbxproj
@@ -611,7 +611,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12.2;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.wearecocoon.YT-Music";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -643,7 +643,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12.2;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.wearecocoon.YT-Music";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/YT Music.xcodeproj/xcshareddata/xcschemes/YT Music.xcscheme
+++ b/YT Music.xcodeproj/xcshareddata/xcschemes/YT Music.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/YT Music.xcodeproj/xcshareddata/xcschemes/YTMusicTests.xcscheme
+++ b/YT Music.xcodeproj/xcshareddata/xcschemes/YTMusicTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/YT Music/Controllers/ViewController.swift
+++ b/YT Music/Controllers/ViewController.swift
@@ -41,8 +41,24 @@ class ViewController: NSViewController {
         userContentController = WKUserContentController()
         userContentController.add(MediaCenter.default, name: "observer")
         webConfiguration.userContentController = userContentController
-        
-        
+
+        let blockRules = """
+            [{
+                "trigger": {
+                    "url-filter": "sw.js"
+                },
+                "action": {
+                    "type": "block"
+                }
+            }]
+         """
+
+        WKContentRuleListStore.default().compileContentRuleList(
+            forIdentifier: "ContentBlockingRules",
+            encodedContentRuleList: blockRules) { (contentRuleList, _) in
+                webConfiguration.userContentController.add(contentRuleList!)
+        }
+
         webView = CustomWebView(frame: .zero, configuration: webConfiguration)
         webView.wantsLayer = true
         webView.layerContentsRedrawPolicy = .onSetNeedsDisplay


### PR DESCRIPTION
The YouTube Music service worker's prefetch and cache seems to be breaking. This PR disables the service worker so that the requests to pull the js reach the server, instead of a broken service worker. For this to work, it requires a min version bump to 10.13. See discussion on #163 