### PR TITLE
(FIX) Display the correct menu title for play/pause

### DIFF
--- a/YT Music/Controllers/MediaCenter.swift
+++ b/YT Music/Controllers/MediaCenter.swift
@@ -62,7 +62,9 @@ class MediaCenter: NSObject, WKScriptMessageHandler, NSUserNotificationCenterDel
     
     var isPlaying = false {
         didSet {
-            (NSApp.delegate as? AppDelegate)?.dockMenu.item(at: 0)?.title = isPlaying ? "Pause" : "Play"
+            let newMenuTitle = isPlaying ? "Pause" : "Play"
+            (NSApp.delegate as? AppDelegate)?.dockMenu.item(at: 0)?.title = newMenuTitle
+            NSApp.mainMenu?.items.filter { $0.title == "Playback" }.first?.submenu?.items.first?.title = newMenuTitle
         }
     }
     

--- a/YT Music/Supporting Files/custom.js
+++ b/YT Music/Supporting Files/custom.js
@@ -20,7 +20,7 @@ window.setTimeout(function() {
       thumbnail: document.querySelector('ytmusic-player-bar .middle-controls img.image').getAttribute('src'),
       progress: parseInt(bar.getAttribute('value')),
       length: parseInt(bar.getAttribute('aria-valuemax')),
-      isPlaying: document.querySelector('.play-pause-button.ytmusic-player-bar').getAttribute('title') == window.yt.msgs_.YTP_PAUSE
+      isPlaying: document.querySelector('.play-pause-button.ytmusic-player-bar').getAttribute('title') == window.yt.msgs_.PAUSE
     })
   });
   


### PR DESCRIPTION
## Problem
The dock and playback menu item was always displaying "Play" as the first option regardless of the current state of the playback.

Fixes #112

## Proposed solution
Looks like the dock menu used to display the correct title at some point but then got broken due to the change on YouTube's side.

After reviewing the code, I've realised that the current "isPlaying" value is read from the webpage once a second by comparing the play button title to the string constant. It looks like the constant name was changed from `YT_PAUSE` to `PAUSE` breaking the implementation.
<img width="191" alt="Screenshot 2022-11-27 at 07 13 56" src="https://user-images.githubusercontent.com/4711044/204124244-1db0487b-1f88-4e70-8df1-50a5302d3fcc.png">

I fixed the implementation by updating the name of the constant in the custom script.

The main menu item on the other hand was always displaying the "Play" option regardless of the current playback. I've used the same logic to update the menu item as well.

## Evidence of testing

Tested by running the app on my machine.

|Before|After|
|--|--|
|![Screenshot 2022-11-27 at 07 09 39](https://user-images.githubusercontent.com/4711044/204124296-ee58e3a8-f82f-443c-8bab-02b96ba2a74a.png)|![Screenshot 2022-11-27 at 07 10 14](https://user-images.githubusercontent.com/4711044/204124298-323d6db0-07d0-48ea-abbc-57c291fdd54e.png)|
