### PR TITLE
(FEAT) Allow turning off push notifications in app preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ DerivedData/
 *.ipa
 *.dSYM.zip
 *.dSYM
+*.DS_Store
 
 # CocoaPods
 #

--- a/YT Music.xcodeproj/project.pbxproj
+++ b/YT Music.xcodeproj/project.pbxproj
@@ -21,9 +21,11 @@
 		28DA92B820D90169004B2A6D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DA92B720D90169004B2A6D /* ViewController.swift */; };
 		28DA92BA20D9016A004B2A6D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 28DA92B920D9016A004B2A6D /* Assets.xcassets */; };
 		28DA92BD20D9016A004B2A6D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 28DA92BB20D9016A004B2A6D /* Main.storyboard */; };
-		4A25279A2847A73200C7E419 /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2527992847A73200C7E419 /* PreferencesViewController.swift */; };
+		4A25279A2847A73200C7E419 /* HotkeyPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2527992847A73200C7E419 /* HotkeyPreferencesViewController.swift */; };
 		4A25279C28481CF100C7E419 /* PreferencesTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A25279B28481CF100C7E419 /* PreferencesTabViewController.swift */; };
 		4A2527A42848580700C7E419 /* KeyboardShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2527A32848580700C7E419 /* KeyboardShortcut.swift */; };
+		BD8455B12933772200F38EB1 /* GeneralPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8455B02933772200F38EB1 /* GeneralPreferencesViewController.swift */; };
+		BD8455B3293377C400F38EB1 /* GeneralPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8455B2293377C400F38EB1 /* GeneralPreferences.swift */; };
 		DD1C43A82A08CC98952A483A /* libPods-YT Music.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 396B6C8C07FADD7D45E2CCC6 /* libPods-YT Music.a */; };
 		DFEE18842697A8D1000913BC /* (null) in Sources */ = {isa = PBXBuildFile; };
 		DFEE188F269B1E18000913BC /* fa.otf in Resources */ = {isa = PBXBuildFile; fileRef = DFEE188E269B1E18000913BC /* fa.otf */; };
@@ -76,10 +78,12 @@
 		28DA92BC20D9016A004B2A6D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		28DA92BE20D9016A004B2A6D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		396B6C8C07FADD7D45E2CCC6 /* libPods-YT Music.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-YT Music.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4A2527992847A73200C7E419 /* PreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
+		4A2527992847A73200C7E419 /* HotkeyPreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyPreferencesViewController.swift; sourceTree = "<group>"; };
 		4A25279B28481CF100C7E419 /* PreferencesTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTabViewController.swift; sourceTree = "<group>"; };
 		4A2527A32848580700C7E419 /* KeyboardShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcut.swift; sourceTree = "<group>"; };
 		5AED565561146EAC97AC8F55 /* Pods-YT Music.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YT Music.debug.xcconfig"; path = "Pods/Target Support Files/Pods-YT Music/Pods-YT Music.debug.xcconfig"; sourceTree = "<group>"; };
+		BD8455B02933772200F38EB1 /* GeneralPreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPreferencesViewController.swift; sourceTree = "<group>"; };
+		BD8455B2293377C400F38EB1 /* GeneralPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPreferences.swift; sourceTree = "<group>"; };
 		DF9D316F37D878F34D8107B0 /* Pods-YT Music.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YT Music.release.xcconfig"; path = "Pods/Target Support Files/Pods-YT Music/Pods-YT Music.release.xcconfig"; sourceTree = "<group>"; };
 		DFEE188A2697B56B000913BC /* TouchBarPrivateApi.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TouchBarPrivateApi.h; sourceTree = "<group>"; };
 		DFEE188B2697B671000913BC /* TouchBarPrivateApi-Bridging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TouchBarPrivateApi-Bridging.h"; sourceTree = "<group>"; };
@@ -127,8 +131,9 @@
 				28DA92B720D90169004B2A6D /* ViewController.swift */,
 				2802617620EE629A001FDDCC /* ViewController + MediaKeys.swift */,
 				2802617A20EE802B001FDDCC /* MediaCenter.swift */,
-				4A2527992847A73200C7E419 /* PreferencesViewController.swift */,
+				4A2527992847A73200C7E419 /* HotkeyPreferencesViewController.swift */,
 				4A25279B28481CF100C7E419 /* PreferencesTabViewController.swift */,
+				BD8455B02933772200F38EB1 /* GeneralPreferencesViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -206,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				4A2527A32848580700C7E419 /* KeyboardShortcut.swift */,
+				BD8455B2293377C400F38EB1 /* GeneralPreferences.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -406,8 +412,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD8455B12933772200F38EB1 /* GeneralPreferencesViewController.swift in Sources */,
 				2802617720EE629A001FDDCC /* ViewController + MediaKeys.swift in Sources */,
 				4A25279C28481CF100C7E419 /* PreferencesTabViewController.swift in Sources */,
+				BD8455B3293377C400F38EB1 /* GeneralPreferences.swift in Sources */,
 				DFEE18A3269B47E7000913BC /* SupportNSTouchBar.swift in Sources */,
 				286AD74320D90E1B00B2F45F /* CustomWindow.swift in Sources */,
 				281F979920E9588A0033D930 /* WindowMovableView.swift in Sources */,
@@ -418,7 +426,7 @@
 				286AD74120D909AB00B2F45F /* CustomWebView.swift in Sources */,
 				DFEE18842697A8D1000913BC /* (null) in Sources */,
 				DFFF993426C58DFE00B14C8D /* TouchBarController.swift in Sources */,
-				4A25279A2847A73200C7E419 /* PreferencesViewController.swift in Sources */,
+				4A25279A2847A73200C7E419 /* HotkeyPreferencesViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YT Music/Base.lproj/Main.storyboard
+++ b/YT Music/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -269,6 +269,7 @@
             <objects>
                 <tabViewController title="Preferences" showSeguePresentationStyle="single" selectedTabViewItemIndex="0" tabStyle="toolbar" id="SHP-Rq-Edu" customClass="PreferencesTabViewController" customModule="YT_Music" customModuleProvider="target" sceneMemberID="viewController">
                     <tabViewItems>
+                        <tabViewItem id="Nda-Nn-7Jl"/>
                         <tabViewItem id="657-bm-f5F"/>
                     </tabViewItems>
                     <tabView key="tabView" type="noTabsNoBorder" id="pEw-jD-OiR">
@@ -281,6 +282,7 @@
                     </tabView>
                     <connections>
                         <outlet property="tabView" destination="pEw-jD-OiR" id="Oz2-bc-XTu"/>
+                        <segue destination="v9I-5X-UXY" kind="relationship" relationship="tabItems" id="J9z-YT-ate"/>
                         <segue destination="k5E-lF-FbM" kind="relationship" relationship="tabItems" id="ha2-k1-S2u"/>
                     </connections>
                 </tabViewController>
@@ -291,13 +293,13 @@
         <!--Hotkeys-->
         <scene sceneID="0eH-qI-SkZ">
             <objects>
-                <viewController title="Hotkeys" id="k5E-lF-FbM" customClass="PreferencesViewController" customModule="YT_Music" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="Hotkeys" id="k5E-lF-FbM" customClass="HotkeyPreferencesViewController" customModule="YT_Music" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="zPj-ER-Yt9">
-                        <rect key="frame" x="0.0" y="0.0" width="459" height="220"/>
+                        <rect key="frame" x="0.0" y="0.0" width="459" height="198"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="x13-w1-cFP">
-                                <rect key="frame" x="18" y="183" width="421" height="18"/>
+                                <rect key="frame" x="18" y="161" width="421" height="18"/>
                                 <buttonCell key="cell" type="check" title="Enable Global Play/Pause Hotkey" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="IHJ-PA-oQc">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -307,7 +309,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GAk-hG-rlX">
-                                <rect key="frame" x="18" y="162" width="423" height="14"/>
+                                <rect key="frame" x="18" y="140" width="423" height="14"/>
                                 <textFieldCell key="cell" title="Allows using Play/Pause global keyboard shortcut - ⌘ ⇧ Spacebar" id="A1P-bH-DJd">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -315,7 +317,7 @@
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="v3p-PO-IHh">
-                                <rect key="frame" x="18" y="121" width="421" height="18"/>
+                                <rect key="frame" x="18" y="99" width="421" height="18"/>
                                 <buttonCell key="cell" type="check" title="Enable Global Next Track Hotkey" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="wdk-Ug-Xn8">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -325,7 +327,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0nR-V1-Slq">
-                                <rect key="frame" x="18" y="100" width="343" height="14"/>
+                                <rect key="frame" x="18" y="78" width="427" height="14"/>
                                 <textFieldCell key="cell" title="Allows using Play/Pause global keyboard shortcut - ⌘ ⇧ PageUp" id="jmF-fH-bsp">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -333,7 +335,7 @@
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="45U-pJ-yMB">
-                                <rect key="frame" x="18" y="59" width="421" height="18"/>
+                                <rect key="frame" x="18" y="37" width="421" height="18"/>
                                 <buttonCell key="cell" type="check" title="Enable Global Previous Track Hotkey" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="joI-Qs-8ro">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -343,7 +345,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xui-VJ-gz4">
-                                <rect key="frame" x="18" y="38" width="358" height="14"/>
+                                <rect key="frame" x="18" y="16" width="427" height="14"/>
                                 <textFieldCell key="cell" title="Allows using Play/Pause global keyboard shortcut - ⌘ ⇧ PageDown" id="1ez-lX-evb">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -356,6 +358,7 @@
                             <constraint firstItem="0nR-V1-Slq" firstAttribute="leading" secondItem="v3p-PO-IHh" secondAttribute="leading" id="Afn-VS-N3q"/>
                             <constraint firstItem="Xui-VJ-gz4" firstAttribute="leading" secondItem="45U-pJ-yMB" secondAttribute="leading" id="CHc-Aw-ArD"/>
                             <constraint firstItem="45U-pJ-yMB" firstAttribute="top" secondItem="0nR-V1-Slq" secondAttribute="bottom" constant="24" id="EDs-xh-idX"/>
+                            <constraint firstAttribute="bottom" secondItem="Xui-VJ-gz4" secondAttribute="bottom" constant="16" id="Mgm-qt-xrM"/>
                             <constraint firstItem="GAk-hG-rlX" firstAttribute="top" secondItem="x13-w1-cFP" secondAttribute="bottom" constant="8" symbolic="YES" id="RV5-el-16h"/>
                             <constraint firstItem="v3p-PO-IHh" firstAttribute="top" secondItem="GAk-hG-rlX" secondAttribute="bottom" constant="24" id="Sa6-wT-exy"/>
                             <constraint firstItem="x13-w1-cFP" firstAttribute="top" secondItem="zPj-ER-Yt9" secondAttribute="top" constant="20" symbolic="YES" id="W9B-de-nsu"/>
@@ -364,8 +367,10 @@
                             <constraint firstAttribute="trailing" secondItem="x13-w1-cFP" secondAttribute="trailing" constant="20" symbolic="YES" id="dTb-ly-iNJ"/>
                             <constraint firstItem="45U-pJ-yMB" firstAttribute="leading" secondItem="zPj-ER-Yt9" secondAttribute="leading" constant="20" symbolic="YES" id="gQG-O6-W7D"/>
                             <constraint firstItem="GAk-hG-rlX" firstAttribute="leading" secondItem="x13-w1-cFP" secondAttribute="leading" id="gfT-dm-47t"/>
+                            <constraint firstAttribute="trailing" secondItem="0nR-V1-Slq" secondAttribute="trailing" constant="16" id="hUQ-rP-On5"/>
                             <constraint firstItem="0nR-V1-Slq" firstAttribute="top" secondItem="v3p-PO-IHh" secondAttribute="bottom" constant="8" symbolic="YES" id="mNl-ir-lYA"/>
                             <constraint firstItem="Xui-VJ-gz4" firstAttribute="top" secondItem="45U-pJ-yMB" secondAttribute="bottom" constant="8" symbolic="YES" id="ngp-6E-Y66"/>
+                            <constraint firstAttribute="trailing" secondItem="Xui-VJ-gz4" secondAttribute="trailing" constant="16" id="uRg-Fo-dSp"/>
                             <constraint firstAttribute="trailing" secondItem="v3p-PO-IHh" secondAttribute="trailing" constant="20" symbolic="YES" id="vA4-1G-7iX"/>
                             <constraint firstItem="v3p-PO-IHh" firstAttribute="leading" secondItem="zPj-ER-Yt9" secondAttribute="leading" constant="20" symbolic="YES" id="vyS-l0-6lk"/>
                         </constraints>
@@ -379,7 +384,7 @@
                 <customObject id="uIw-2e-8tr" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <userDefaultsController representsSharedInstance="YES" id="hpa-VM-qxH"/>
             </objects>
-            <point key="canvasLocation" x="833.5" y="659"/>
+            <point key="canvasLocation" x="843" y="690"/>
         </scene>
         <!--YouTube Music-->
         <scene sceneID="hIz-AP-VOD">
@@ -393,6 +398,52 @@
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="75" y="907"/>
+        </scene>
+        <!--General-->
+        <scene sceneID="7Uh-NS-8sI">
+            <objects>
+                <viewController title="General" id="v9I-5X-UXY" customClass="GeneralPreferencesViewController" customModule="YT_Music" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="WZc-R3-nRi">
+                        <rect key="frame" x="0.0" y="0.0" width="459" height="74"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y2a-CJ-Gpy">
+                                <rect key="frame" x="18" y="37" width="421" height="18"/>
+                                <buttonCell key="cell" type="check" title="Enable push notifications" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8Ws-LH-B1W">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="pushNotificationsCheckboxToggled:" target="v9I-5X-UXY" id="hJe-La-wxq"/>
+                                </connections>
+                            </button>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xkS-oy-Nar">
+                                <rect key="frame" x="18" y="16" width="423" height="14"/>
+                                <textFieldCell key="cell" title="Displays push notifications whenever a new song has started to play" id="5C2-O0-VZs">
+                                    <font key="font" metaFont="smallSystem"/>
+                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="xkS-oy-Nar" firstAttribute="leading" secondItem="y2a-CJ-Gpy" secondAttribute="leading" id="G5i-2q-Rg6"/>
+                            <constraint firstAttribute="bottom" secondItem="xkS-oy-Nar" secondAttribute="bottom" constant="16" id="Jcw-xx-KVo"/>
+                            <constraint firstItem="xkS-oy-Nar" firstAttribute="top" secondItem="y2a-CJ-Gpy" secondAttribute="bottom" constant="8" symbolic="YES" id="h6b-4N-sWj"/>
+                            <constraint firstAttribute="trailing" secondItem="y2a-CJ-Gpy" secondAttribute="trailing" constant="20" symbolic="YES" id="jId-Au-kqu"/>
+                            <constraint firstItem="y2a-CJ-Gpy" firstAttribute="top" secondItem="WZc-R3-nRi" secondAttribute="top" constant="20" symbolic="YES" id="o1a-21-MTb"/>
+                            <constraint firstAttribute="trailing" secondItem="xkS-oy-Nar" secondAttribute="trailing" constant="20" symbolic="YES" id="rwt-8G-FhS"/>
+                            <constraint firstItem="y2a-CJ-Gpy" firstAttribute="leading" secondItem="WZc-R3-nRi" secondAttribute="leading" constant="20" symbolic="YES" id="zUa-RJ-Aor"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="pushNotificationsCheckbox" destination="y2a-CJ-Gpy" id="45n-pW-Gaj"/>
+                    </connections>
+                </viewController>
+                <customObject id="RBU-ed-syr" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <userDefaultsController id="4u7-tS-zkF"/>
+            </objects>
+            <point key="canvasLocation" x="1330" y="690"/>
         </scene>
     </scenes>
 </document>

--- a/YT Music/Controllers/GeneralPreferencesViewController.swift
+++ b/YT Music/Controllers/GeneralPreferencesViewController.swift
@@ -1,0 +1,26 @@
+//
+//  GeneralPreferencesViewController.swift
+//  YT Music
+//
+//  Created by Allan Spreys on 27/11/2022.
+//  Copyright © 2022 Cocoon Development Ltd. All rights reserved.
+//
+
+import Foundation
+
+class GeneralPreferencesViewController: NSViewController {
+    // MARK: - Outlets
+    @IBOutlet weak var pushNotificationsCheckbox: NSButton!
+
+    // MARK: - lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        pushNotificationsCheckbox.state = GeneralPreferences.pushNotifications.isEnabled.asControlState
+    }
+
+    // MARK: - actions
+    @IBAction func pushNotificationsCheckboxToggled(_ sender: NSButton) {
+        GeneralPreferences.pushNotifications.setEnabled(sender.state.rawValue != 0)
+    }
+}

--- a/YT Music/Controllers/HotkeyPreferencesViewController.swift
+++ b/YT Music/Controllers/HotkeyPreferencesViewController.swift
@@ -1,5 +1,5 @@
 //
-//  PreferencesViewController.swift
+//  HotkeyPreferencesViewController.swift
 //  YT Music
 //
 //  Created by Rafael Veronezi on 01/06/22.
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class PreferencesViewController: NSViewController {
+class HotkeyPreferencesViewController: NSViewController {
 
     // MARK: - Outlets
     
@@ -24,11 +24,6 @@ class PreferencesViewController: NSViewController {
         globalPlayPauseCheckbox.state = KeyboardShortcut.playPause.isEnabled.asControlState
         globalNextTrackCheckbox.state = KeyboardShortcut.next.isEnabled.asControlState
         globalPreviousTrackCheckbox.state = KeyboardShortcut.previous.isEnabled.asControlState
-    }
-    
-    override func viewWillAppear() {
-        super.viewWillAppear()
-        preferredContentSize = NSSize(width: self.view.frame.width, height: 220)
     }
     
     // MARK: - Action Methods

--- a/YT Music/Controllers/MediaCenter.swift
+++ b/YT Music/Controllers/MediaCenter.swift
@@ -88,13 +88,14 @@ class MediaCenter: NSObject, WKScriptMessageHandler, NSUserNotificationCenterDel
     
     /// Sends an `NSUserNotification` regarding the song change.
     func sendNotificationIfRequired() {
-        guard let title = title,
-        let by = by,
-        let thumbnail = thumbnail,
-        let thumbnailURL = URL(string: thumbnail),
-        title != "",
-        by != "",
-        titleChanged || byChanged else {
+        guard GeneralPreferences.pushNotifications.isEnabled,
+            let title,
+            let by,
+            let thumbnail,
+            let thumbnailURL = URL(string: thumbnail),
+            !title.isEmpty,
+            !by.isEmpty,
+            titleChanged || byChanged else {
             return
         }
         

--- a/YT Music/Controllers/PreferencesTabViewController.swift
+++ b/YT Music/Controllers/PreferencesTabViewController.swift
@@ -12,12 +12,14 @@ class PreferencesTabViewController: NSTabViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        if #available(macOS 11.0, *) {
-            tabViewItems[0].image = NSImage(systemSymbolName: "keyboard", accessibilityDescription: "Keyboard Shortcuts")
-        } else {
-            tabViewItems[0].image = NSImage(named: NSImage.preferencesGeneralName)
+
+        guard #available(macOS 11.0, *) else {
+            tabViewItems.forEach { $0.image = NSImage(named: NSImage.preferencesGeneralName) }
+            return
         }
+
+        tabViewItems[0].image = NSImage(systemSymbolName: "gear", accessibilityDescription: "General preferences")
+        tabViewItems[1].image = NSImage(systemSymbolName: "keyboard", accessibilityDescription: "Keyboard Shortcuts")
     }
     
 }

--- a/YT Music/Models/GeneralPreferences.swift
+++ b/YT Music/Models/GeneralPreferences.swift
@@ -1,0 +1,29 @@
+//
+//  GeneralPreferences.swift
+//  YT Music
+//
+//  Created by Allan Spreys on 27/11/2022.
+//  Copyright © 2022 Cocoon Development Ltd. All rights reserved.
+//
+
+import Foundation
+
+public enum GeneralPreferences: CaseIterable {
+    case pushNotifications
+
+    private var preferenceKey: String {
+        switch self {
+        case .pushNotifications: return "isEnablePushNotifications"
+        }
+    }
+
+    var isEnabled: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: preferenceKey, default: true)
+        }
+    }
+
+    func setEnabled(_ value: Bool) {
+        UserDefaults.standard.set(value, forKey: preferenceKey)
+    }
+}


### PR DESCRIPTION
## Problem statement
Personally, I find push notifications for each new song to be a bit distracting, but I understand that others may like to have them.

## Proposed solution
I've added a general preference pane that includes a setting to toggle the push notifications on and off. It's enabled by default to preserve the previous behaviour for existing users.

## Evidence of testing
Ensured that the push notifications are still being displayed when the setting is turned on.
![Screenshot 2022-11-27 at 11 31 46](https://user-images.githubusercontent.com/4711044/204132961-c3b5dd42-860f-4974-8df0-efaf42433919.png)

Checked that the notifications aren't being displayed when the preference is turned off (no screenshot).

Ensured that the new pane displays remembers the last setting:
![Screenshot 2022-11-27 at 11 07 01](https://user-images.githubusercontent.com/4711044/204132996-508bec79-63b8-4720-a855-b382fce9188c.png)

Regression tested the push notifications pane to ensure that it is displayed correctly:
![Screenshot 2022-11-27 at 11 20 06](https://user-images.githubusercontent.com/4711044/204133010-6c4dbab8-f3ba-4b1c-8496-246a0cf39ea7.png)

## Additional changes
While working through the preference changes, I've noticed a few things that could be improved, so I've included them here. Let me know if you'd rather not have them or have them in a separate PR:
* Ignoring all [*.DS_Store](https://en.wikipedia.org/wiki/.DS_Store) file from version control.
* Renamed `PreferencesViewController` to `HotkeyPreferencesViewController`. Now that we have general and hokey preference panes, it makes sense to give a more descriptive name.
* Added missing auto layout constraints in the preference pane. Some of the trailing constraints were missing forcing us to specify the height of the view controller. Once I added the missing constraints, I was able to remove the code that was setting the height of the view.
* I've used the modern `guard let variable` syntax instead of the legacy `guard let variable = variable` to unwrap optionals.